### PR TITLE
Add schema.org structured data validation

### DIFF
--- a/schema_validator.py
+++ b/schema_validator.py
@@ -1,0 +1,47 @@
+import requests
+import jsonschema
+
+_schema_cache = {}
+
+
+def _load_schema(schema_type: str):
+    """Fetch JSON Schema for a given schema.org type."""
+    if schema_type in _schema_cache:
+        return _schema_cache[schema_type]
+    url = f"https://schema.org/{schema_type}.schema.json"
+    try:
+        response = requests.get(url, timeout=10)
+        if response.status_code == 200:
+            schema = response.json()
+            _schema_cache[schema_type] = schema
+            return schema
+    except Exception:
+        pass
+    return None
+
+
+def validate(data: dict):
+    """Validate structured data dict using schema.org definitions.
+
+    Parameters
+    ----------
+    data: dict
+        Structured data item in JSON-LD format.
+
+    Returns
+    -------
+    list[str]
+        List of validation error messages. Empty if valid or schema missing.
+    """
+    schema_type = data.get("@type")
+    if isinstance(schema_type, list):
+        schema_type = schema_type[0]
+    if not schema_type:
+        return ["Missing @type"]
+
+    schema = _load_schema(schema_type)
+    if not schema:
+        return [f"Schema for {schema_type} not found at schema.org"]
+
+    validator = jsonschema.Draft2020Validator(schema)
+    return [error.message for error in validator.iter_errors(data)]

--- a/scrape.py
+++ b/scrape.py
@@ -2,6 +2,10 @@ import requests
 from bs4 import BeautifulSoup
 import xml.etree.ElementTree as ET
 import xml.dom.minidom as md
+import json
+import extruct
+from w3lib.html import get_base_url
+import schema_validator
 
 url = "https://github.com/"
 response = requests.get(url)
@@ -41,6 +45,45 @@ img_parent = ET.SubElement(root, "Images")
 for img in soup.find_all("img"):
     ET.SubElement(img_parent, "ImageAlt").text = img.get("alt", "")
 
+structured_results = []
+
+# JSON-LD scripts
+for script in soup.find_all("script", type="application/ld+json"):
+    try:
+        data = json.loads(script.string)
+    except (json.JSONDecodeError, TypeError):
+        continue
+    items = data if isinstance(data, list) else [data]
+    for item in items:
+        errors = schema_validator.validate(item)
+        structured_results.append(("json-ld", item.get("@type"), errors))
+
+# Microdata
+base_url = get_base_url(response.text, url)
+extracted = extruct.extract(response.text, base_url=base_url, syntaxes=["microdata"])
+for item in extracted.get("microdata", []):
+    schema_type_url = item.get("type")
+    schema_type = schema_type_url.split("/")[-1] if schema_type_url else None
+    data = {"@type": schema_type}
+    properties = item.get("properties", {})
+    if isinstance(properties, dict):
+        data.update(properties)
+    errors = schema_validator.validate(data)
+    structured_results.append(("microdata", schema_type, errors))
+
+sd_parent = ET.SubElement(root, "StructuredData")
+for source, sd_type, errors in structured_results:
+    item_elem = ET.SubElement(sd_parent, "Item")
+    ET.SubElement(item_elem, "Source").text = source
+    ET.SubElement(item_elem, "Type").text = sd_type or ""
+    if errors:
+        ET.SubElement(item_elem, "Valid").text = "false"
+        errors_elem = ET.SubElement(item_elem, "Errors")
+        for err in errors:
+            ET.SubElement(errors_elem, "Error").text = err
+    else:
+        ET.SubElement(item_elem, "Valid").text = "true"
+
 tree = ET.ElementTree(root)
 filename = " ".join(title.split()[:2]) + ".xml"
 
@@ -50,4 +93,16 @@ dom = md.parseString(xml_str)
 with open(filename, "w") as f:
     f.write(dom.toprettyxml())
 
+for source, sd_type, errors in structured_results:
+    if errors:
+        print(f"{source} {sd_type} validation errors:")
+        for err in errors:
+            print(f" - {err}")
+    else:
+        print(f"{source} {sd_type} is valid")
+
+if not structured_results:
+    print("No structured data found")
+
 print("Output written to:", filename)
+


### PR DESCRIPTION
## Summary
- validate structured data items with schema.org definitions via new `schema_validator`
- parse JSON-LD and microdata in `scrape.py` and report validation results in the metadata XML

## Testing
- `python -m py_compile schema_validator.py scrape.py`
- `python scrape.py | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_b_68ba624e468483229a24a03cd2d0a9d7