### PR TITLE
Add SEO audit module and summary reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,11 @@ The script will output an XML file in the same directory as the script, with the
 - H1 tags
 - H2 tags
 - Image alt text
+- SEO audit warnings (title/meta lengths, heading hierarchy, keyword density)
 
 If any of the metadata is missing on the website, the script will insert "missing" as the value for that metadata.
+
+The generated report also contains a short summary table of the key SEO metrics.
 
 ## Authors
 

--- a/scrape.py
+++ b/scrape.py
@@ -3,51 +3,68 @@ from bs4 import BeautifulSoup
 import xml.etree.ElementTree as ET
 import xml.dom.minidom as md
 
-url = "https://github.com/"
-response = requests.get(url)
-soup = BeautifulSoup(response.content, "html.parser")
+import seo_audit
 
-title = soup.find("title").text.strip()
-
-metadata = [
+METADATA = [
     ("description", "content"),
     ("keywords", "content"),
     ("canonical_url", "href"),
     ("robots", "content"),
     ("og_title", "content"),
     ("og_description", "content"),
-    ("og_image", "content")
+    ("og_image", "content"),
 ]
 
-root = ET.Element("metadata")
-ET.SubElement(root, "title").text = title
 
-for tag, attr in metadata:
-    element = soup.find("meta", attrs={"name": tag})
-    if element:
-        ET.SubElement(root, tag).text = element.get(attr, "")
-    else:
-        ET.SubElement(root, tag).text = "missing"
+def scrape(url: str):
+    """Scrape the given URL and return metadata with SEO audit warnings."""
+    response = requests.get(url)
+    soup = BeautifulSoup(response.content, "html.parser")
 
-h1_parent = ET.SubElement(root, "H1")
-for h1 in soup.find_all("h1"):
-    ET.SubElement(h1_parent, "H1Tag").text = h1.text.strip()
+    title_tag = soup.find("title")
+    title = title_tag.text.strip() if title_tag else ""
 
-h2_parent = ET.SubElement(root, "H2")
-for h2 in soup.find_all("h2"):
-    ET.SubElement(h2_parent, "H2Tag").text = h2.text.strip()
+    root = ET.Element("metadata")
+    ET.SubElement(root, "title").text = title
 
-img_parent = ET.SubElement(root, "Images")
-for img in soup.find_all("img"):
-    ET.SubElement(img_parent, "ImageAlt").text = img.get("alt", "")
+    for tag, attr in METADATA:
+        element = soup.find("meta", attrs={"name": tag})
+        if element:
+            ET.SubElement(root, tag).text = element.get(attr, "")
+        else:
+            ET.SubElement(root, tag).text = "missing"
 
-tree = ET.ElementTree(root)
-filename = " ".join(title.split()[:2]) + ".xml"
+    h1_parent = ET.SubElement(root, "H1")
+    for h1 in soup.find_all("h1"):
+        ET.SubElement(h1_parent, "H1Tag").text = h1.text.strip()
 
-xml_str = ET.tostring(root, encoding="utf-8")
-dom = md.parseString(xml_str)
+    h2_parent = ET.SubElement(root, "H2")
+    for h2 in soup.find_all("h2"):
+        ET.SubElement(h2_parent, "H2Tag").text = h2.text.strip()
 
-with open(filename, "w") as f:
-    f.write(dom.toprettyxml())
+    img_parent = ET.SubElement(root, "Images")
+    for img in soup.find_all("img"):
+        ET.SubElement(img_parent, "ImageAlt").text = img.get("alt", "")
 
-print("Output written to:", filename)
+    audit = seo_audit.analyze(soup)
+    warnings_parent = ET.SubElement(root, "Warnings")
+    for warning in audit["warnings"]:
+        ET.SubElement(warnings_parent, "Warning").text = warning
+
+    summary_parent = ET.SubElement(root, "Summary")
+    summary_parent.text = "\n" + audit["summary"]
+
+    xml_str = ET.tostring(root, encoding="utf-8")
+    dom = md.parseString(xml_str)
+
+    filename = " ".join(title.split()[:2]) + ".xml"
+    with open(filename, "w") as f:
+        f.write(dom.toprettyxml())
+
+    print("Output written to:", filename)
+    return {"warnings": audit["warnings"], "filename": filename}
+
+
+if __name__ == "__main__":
+    URL = "https://github.com/"
+    scrape(URL)

--- a/seo_audit.py
+++ b/seo_audit.py
@@ -1,0 +1,80 @@
+import re
+from collections import Counter
+from typing import List, Dict, Any
+
+
+def analyze(soup) -> Dict[str, Any]:
+    """Analyze a BeautifulSoup object for basic SEO metrics.
+
+    Returns a dictionary with title and meta description lengths,
+    heading hierarchy, keyword density and any generated warnings.
+    """
+    warnings: List[str] = []
+
+    # Title length
+    title_tag = soup.find("title")
+    title_text = title_tag.get_text(strip=True) if title_tag else ""
+    title_length = len(title_text)
+    if title_length == 0 or title_length > 60:
+        warnings.append(f"Title length {title_length} characters.")
+
+    # Meta description length
+    desc_tag = soup.find("meta", attrs={"name": "description"})
+    desc_text = desc_tag.get("content", "").strip() if desc_tag else ""
+    meta_length = len(desc_text)
+    if meta_length == 0 or not 50 <= meta_length <= 160:
+        warnings.append(f"Meta description length {meta_length} characters.")
+
+    # Heading hierarchy
+    heading_tags = soup.find_all(re.compile("^h[1-6]$"))
+    hierarchy = [int(tag.name[1]) for tag in heading_tags]
+    for i in range(1, len(hierarchy)):
+        if hierarchy[i] > hierarchy[i - 1] + 1:
+            warnings.append("Improper heading hierarchy.")
+            break
+
+    # Keyword density
+    body_text = soup.get_text(" ", strip=True)
+    words = re.findall(r"\b\w+\b", body_text.lower())
+    total_words = len(words) or 1
+    counts = Counter(words)
+    density = [
+        {
+            "keyword": word,
+            "count": count,
+            "density": round(count / total_words * 100, 2),
+        }
+        for word, count in counts.most_common(10)
+    ]
+
+    summary = _summary_table(title_length, meta_length, hierarchy, density)
+    return {
+        "title_length": title_length,
+        "meta_description_length": meta_length,
+        "heading_hierarchy": hierarchy,
+        "keyword_density": density,
+        "warnings": warnings,
+        "summary": summary,
+    }
+
+
+def _summary_table(title_len: int, meta_len: int, hierarchy: List[int], density: List[Dict[str, Any]]) -> str:
+    """Create a simple text table summarizing the analysis."""
+    rows = [
+        ("Title Length", str(title_len)),
+        ("Meta Description Length", str(meta_len)),
+        (
+            "Heading Hierarchy",
+            " > ".join(f"H{lvl}" for lvl in hierarchy) if hierarchy else "",
+        ),
+    ]
+    top_keywords = ", ".join(
+        f"{item['keyword']} ({item['density']}%)" for item in density[:3]
+    )
+    rows.append(("Top Keywords", top_keywords))
+
+    col_width = max(len(r[0]) for r in rows) + 2
+    lines = [f"{'Metric'.ljust(col_width)}Value", f"{'-' * (col_width + 5)}"]
+    for metric, value in rows:
+        lines.append(f"{metric.ljust(col_width)}{value}")
+    return "\n".join(lines)


### PR DESCRIPTION
## Summary
- add `seo_audit` module to compute title and meta lengths, heading hierarchy, and keyword density
- integrate seo audit into scraper, returning warnings and summary table
- update README with new audit features

## Testing
- `python -m py_compile seo_audit.py scrape.py`
- `python scrape.py`

------
https://chatgpt.com/codex/tasks/task_b_68ba625587b083228ffbb35ce12d89d6