### PR TITLE
Add Google Search status updates integration

### DIFF
--- a/google_updates.py
+++ b/google_updates.py
@@ -1,0 +1,50 @@
+import json
+import os
+from datetime import datetime, timedelta, timezone
+from typing import List, Dict
+
+import requests
+
+PRODUCT_ID = "rGHU1u87FJnkP6W2GwMi"
+INCIDENTS_URL = "https://status.search.google.com/incidents.json"
+UPDATES_FILE = "updates.json"
+
+def fetch_and_store_updates() -> List[Dict]:
+    """Fetch incidents for the product and store them locally."""
+    response = requests.get(INCIDENTS_URL, timeout=10)
+    response.raise_for_status()
+    incidents = response.json()
+    product_incidents = [
+        inc for inc in incidents
+        if inc.get("service_key") == PRODUCT_ID
+        or any(p.get("id") == PRODUCT_ID for p in inc.get("affected_products", []))
+    ]
+    with open(UPDATES_FILE, "w", encoding="utf-8") as f:
+        json.dump(product_incidents, f, indent=2)
+    return product_incidents
+
+def get_recent_updates(days: int = 30) -> List[Dict]:
+    """Return updates from the last ``days`` days.
+
+    Updates are fetched from Google's Search Status Dashboard and cached
+    locally in ``updates.json``.
+    """
+    try:
+        data = fetch_and_store_updates()
+    except Exception:
+        if not os.path.exists(UPDATES_FILE):
+            raise
+        with open(UPDATES_FILE, "r", encoding="utf-8") as f:
+            data = json.load(f)
+
+    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+    recent = []
+    for inc in data:
+        when = inc.get("most_recent_update", {}).get("when") or inc.get("begin")
+        try:
+            when_dt = datetime.fromisoformat(when.replace("Z", "+00:00"))
+        except Exception:
+            continue
+        if when_dt >= cutoff:
+            recent.append(inc)
+    return recent

--- a/scrape.py
+++ b/scrape.py
@@ -1,53 +1,79 @@
+import argparse
 import requests
 from bs4 import BeautifulSoup
 import xml.etree.ElementTree as ET
 import xml.dom.minidom as md
 
-url = "https://github.com/"
-response = requests.get(url)
-soup = BeautifulSoup(response.content, "html.parser")
+def scrape() -> str:
+    url = "https://github.com/"
+    response = requests.get(url)
+    soup = BeautifulSoup(response.content, "html.parser")
 
-title = soup.find("title").text.strip()
+    title = soup.find("title").text.strip()
 
-metadata = [
-    ("description", "content"),
-    ("keywords", "content"),
-    ("canonical_url", "href"),
-    ("robots", "content"),
-    ("og_title", "content"),
-    ("og_description", "content"),
-    ("og_image", "content")
-]
+    metadata = [
+        ("description", "content"),
+        ("keywords", "content"),
+        ("canonical_url", "href"),
+        ("robots", "content"),
+        ("og_title", "content"),
+        ("og_description", "content"),
+        ("og_image", "content")
+    ]
 
-root = ET.Element("metadata")
-ET.SubElement(root, "title").text = title
+    root = ET.Element("metadata")
+    ET.SubElement(root, "title").text = title
 
-for tag, attr in metadata:
-    element = soup.find("meta", attrs={"name": tag})
-    if element:
-        ET.SubElement(root, tag).text = element.get(attr, "")
-    else:
-        ET.SubElement(root, tag).text = "missing"
+    for tag, attr in metadata:
+        element = soup.find("meta", attrs={"name": tag})
+        if element:
+            ET.SubElement(root, tag).text = element.get(attr, "")
+        else:
+            ET.SubElement(root, tag).text = "missing"
 
-h1_parent = ET.SubElement(root, "H1")
-for h1 in soup.find_all("h1"):
-    ET.SubElement(h1_parent, "H1Tag").text = h1.text.strip()
+    h1_parent = ET.SubElement(root, "H1")
+    for h1 in soup.find_all("h1"):
+        ET.SubElement(h1_parent, "H1Tag").text = h1.text.strip()
 
-h2_parent = ET.SubElement(root, "H2")
-for h2 in soup.find_all("h2"):
-    ET.SubElement(h2_parent, "H2Tag").text = h2.text.strip()
+    h2_parent = ET.SubElement(root, "H2")
+    for h2 in soup.find_all("h2"):
+        ET.SubElement(h2_parent, "H2Tag").text = h2.text.strip()
 
-img_parent = ET.SubElement(root, "Images")
-for img in soup.find_all("img"):
-    ET.SubElement(img_parent, "ImageAlt").text = img.get("alt", "")
+    img_parent = ET.SubElement(root, "Images")
+    for img in soup.find_all("img"):
+        ET.SubElement(img_parent, "ImageAlt").text = img.get("alt", "")
 
-tree = ET.ElementTree(root)
-filename = " ".join(title.split()[:2]) + ".xml"
+    tree = ET.ElementTree(root)
+    filename = " ".join(title.split()[:2]) + ".xml"
 
-xml_str = ET.tostring(root, encoding="utf-8")
-dom = md.parseString(xml_str)
+    xml_str = ET.tostring(root, encoding="utf-8")
+    dom = md.parseString(xml_str)
 
-with open(filename, "w") as f:
-    f.write(dom.toprettyxml())
+    with open(filename, "w") as f:
+        f.write(dom.toprettyxml())
+    return filename
 
-print("Output written to:", filename)
+def main():
+    parser = argparse.ArgumentParser(description="Simple scraper")
+    parser.add_argument("--check-updates", action="store_true", help="Show recent Google Search updates")
+    args = parser.parse_args()
+
+    filename = scrape()
+    print("Output written to:", filename)
+
+    if args.check_updates:
+        from google_updates import get_recent_updates
+
+        updates = get_recent_updates()
+        if updates:
+            print("Recent Google updates:")
+            for inc in updates:
+                info = inc.get("most_recent_update", {})
+                when = info.get("when", "")
+                text = info.get("text", "")
+                print(f"- {when}: {text}")
+        else:
+            print("No recent updates found.")
+
+if __name__ == "__main__":
+    main()

--- a/updates.json
+++ b/updates.json
@@ -1,0 +1,252 @@
+[
+  {
+    "id": "a7Aainy6E9rZsmfq82xt",
+    "number": "10431133316204073730",
+    "begin": "2025-08-26T16:00:00+00:00",
+    "created": "2025-08-26T16:02:38+00:00",
+    "modified": "2025-08-26T16:02:38+00:00",
+    "external_desc": "August 2025 spam update",
+    "updates": [
+      {
+        "created": "2025-08-26T16:02:38+00:00",
+        "modified": "2025-08-26T16:02:38+00:00",
+        "when": "2025-08-26T16:02:38+00:00",
+        "text": "Released the August 2025 spam update <https://developers.google.com/search/docs/appearance/spam-updates>, which applies globally and to all languages. The rollout may take a few weeks to complete.",
+        "status": "SERVICE_INFORMATION"
+      }
+    ],
+    "most_recent_update": {
+      "created": "2025-08-26T16:02:38+00:00",
+      "modified": "2025-08-26T16:02:38+00:00",
+      "when": "2025-08-26T16:02:38+00:00",
+      "text": "Released the August 2025 spam update <https://developers.google.com/search/docs/appearance/spam-updates>, which applies globally and to all languages. The rollout may take a few weeks to complete.",
+      "status": "SERVICE_INFORMATION"
+    },
+    "status_impact": "SERVICE_INFORMATION",
+    "severity": "low",
+    "service_key": "rGHU1u87FJnkP6W2GwMi",
+    "service_name": "Ranking",
+    "affected_products": [
+      {
+        "title": "Ranking",
+        "id": "rGHU1u87FJnkP6W2GwMi"
+      }
+    ],
+    "uri": "incidents/a7Aainy6E9rZsmfq82xt"
+  },
+  {
+    "id": "riq1AuqETW46NfBCe5NT",
+    "number": "1033835186176777790",
+    "begin": "2025-06-30T14:30:00+00:00",
+    "created": "2025-06-30T14:34:35+00:00",
+    "end": "2025-07-17T08:00:00+00:00",
+    "modified": "2025-07-17T08:19:31+00:00",
+    "external_desc": "June 2025 core update",
+    "updates": [
+      {
+        "created": "2025-07-17T08:18:52+00:00",
+        "modified": "2025-07-17T08:19:31+00:00",
+        "when": "2025-07-17T08:18:52+00:00",
+        "text": "The rollout was complete as of July 17, 2025.",
+        "status": "AVAILABLE"
+      },
+      {
+        "created": "2025-06-30T14:34:35+00:00",
+        "modified": "2025-07-17T08:18:52+00:00",
+        "when": "2025-06-30T14:34:35+00:00",
+        "text": "Released the June 2025 core update <https://developers.google.com/search/updates/core-updates>. The rollout may take up to 3 weeks to complete.",
+        "status": "SERVICE_INFORMATION"
+      }
+    ],
+    "most_recent_update": {
+      "created": "2025-07-17T08:18:52+00:00",
+      "modified": "2025-07-17T08:19:31+00:00",
+      "when": "2025-07-17T08:18:52+00:00",
+      "text": "The rollout was complete as of July 17, 2025.",
+      "status": "AVAILABLE"
+    },
+    "status_impact": "SERVICE_INFORMATION",
+    "severity": "low",
+    "service_key": "rGHU1u87FJnkP6W2GwMi",
+    "service_name": "Ranking",
+    "affected_products": [
+      {
+        "title": "Ranking",
+        "id": "rGHU1u87FJnkP6W2GwMi"
+      }
+    ],
+    "uri": "incidents/riq1AuqETW46NfBCe5NT"
+  },
+  {
+    "id": "zpmwuSwifjDjfrVdaZUx",
+    "number": "13902899793949109119",
+    "begin": "2025-03-13T16:00:00+00:00",
+    "created": "2025-03-13T16:23:31+00:00",
+    "end": "2025-03-27T12:35:00+00:00",
+    "modified": "2025-03-27T12:34:35+00:00",
+    "external_desc": "March 2025 core update",
+    "updates": [
+      {
+        "created": "2025-03-27T12:34:15+00:00",
+        "modified": "2025-03-27T12:34:35+00:00",
+        "when": "2025-03-27T12:34:15+00:00",
+        "text": "The rollout was complete as of March 27, 2025.",
+        "status": "AVAILABLE"
+      },
+      {
+        "created": "2025-03-13T16:23:31+00:00",
+        "modified": "2025-03-27T12:34:15+00:00",
+        "when": "2025-03-13T16:23:31+00:00",
+        "text": "Released the March 2025 core update <https://developers.google.com/search/updates/core-updates>. The rollout may take up to 2 weeks to complete.",
+        "status": "SERVICE_INFORMATION"
+      }
+    ],
+    "most_recent_update": {
+      "created": "2025-03-27T12:34:15+00:00",
+      "modified": "2025-03-27T12:34:35+00:00",
+      "when": "2025-03-27T12:34:15+00:00",
+      "text": "The rollout was complete as of March 27, 2025.",
+      "status": "AVAILABLE"
+    },
+    "status_impact": "SERVICE_INFORMATION",
+    "severity": "low",
+    "service_key": "rGHU1u87FJnkP6W2GwMi",
+    "service_name": "Ranking",
+    "affected_products": [
+      {
+        "title": "Ranking",
+        "id": "rGHU1u87FJnkP6W2GwMi"
+      }
+    ],
+    "uri": "incidents/zpmwuSwifjDjfrVdaZUx"
+  },
+  {
+    "id": "UUq2WSouY7PhSm8zvtD1",
+    "number": "6370929841914097168",
+    "begin": "2024-12-19T17:00:00+00:00",
+    "created": "2024-12-19T17:01:50+00:00",
+    "end": "2024-12-26T19:00:00+00:00",
+    "modified": "2024-12-26T19:04:14+00:00",
+    "external_desc": "December 2024 spam update",
+    "updates": [
+      {
+        "created": "2024-12-26T19:03:43+00:00",
+        "modified": "2024-12-26T19:04:14+00:00",
+        "when": "2024-12-26T19:03:43+00:00",
+        "text": "The rollout was complete as of December 26, 2024.",
+        "status": "AVAILABLE"
+      },
+      {
+        "created": "2024-12-19T17:01:50+00:00",
+        "modified": "2024-12-26T19:03:43+00:00",
+        "when": "2024-12-19T17:01:50+00:00",
+        "text": "Released the December 2024 spam update <https://developers.google.com/search/updates/spam-updates>, which applies globally and to all languages. The rollout may take up to 1 week to complete.",
+        "status": "SERVICE_INFORMATION"
+      }
+    ],
+    "most_recent_update": {
+      "created": "2024-12-26T19:03:43+00:00",
+      "modified": "2024-12-26T19:04:14+00:00",
+      "when": "2024-12-26T19:03:43+00:00",
+      "text": "The rollout was complete as of December 26, 2024.",
+      "status": "AVAILABLE"
+    },
+    "status_impact": "SERVICE_INFORMATION",
+    "severity": "low",
+    "service_key": "rGHU1u87FJnkP6W2GwMi",
+    "service_name": "Ranking",
+    "affected_products": [
+      {
+        "title": "Ranking",
+        "id": "rGHU1u87FJnkP6W2GwMi"
+      }
+    ],
+    "uri": "incidents/UUq2WSouY7PhSm8zvtD1"
+  },
+  {
+    "id": "V9nDKuo6nWKh2ThBALgA",
+    "number": "9858121600480151600",
+    "begin": "2024-12-12T15:30:00+00:00",
+    "created": "2024-12-12T15:46:11+00:00",
+    "end": "2024-12-18T19:00:00+00:00",
+    "modified": "2024-12-19T14:50:28+00:00",
+    "external_desc": "December 2024 core update",
+    "updates": [
+      {
+        "created": "2024-12-18T19:00:11+00:00",
+        "modified": "2024-12-19T14:50:28+00:00",
+        "when": "2024-12-18T19:00:11+00:00",
+        "text": "The rollout was complete as of December 18, 2024.",
+        "status": "AVAILABLE"
+      },
+      {
+        "created": "2024-12-12T15:46:11+00:00",
+        "modified": "2024-12-18T19:00:11+00:00",
+        "when": "2024-12-12T15:46:11+00:00",
+        "text": "Released the December 2024 core update <https://developers.google.com/search/updates/core-updates>. The rollout may take up to 2 weeks to complete.",
+        "status": "SERVICE_INFORMATION"
+      }
+    ],
+    "most_recent_update": {
+      "created": "2024-12-18T19:00:11+00:00",
+      "modified": "2024-12-19T14:50:28+00:00",
+      "when": "2024-12-18T19:00:11+00:00",
+      "text": "The rollout was complete as of December 18, 2024.",
+      "status": "AVAILABLE"
+    },
+    "status_impact": "SERVICE_INFORMATION",
+    "severity": "low",
+    "service_key": "rGHU1u87FJnkP6W2GwMi",
+    "service_name": "Ranking",
+    "affected_products": [
+      {
+        "title": "Ranking",
+        "id": "rGHU1u87FJnkP6W2GwMi"
+      }
+    ],
+    "uri": "incidents/V9nDKuo6nWKh2ThBALgA"
+  },
+  {
+    "id": "G7rp11wqTaTGn6JjiPF3",
+    "number": "16347385696646448959",
+    "begin": "2024-11-11T19:00:00+00:00",
+    "created": "2024-11-11T21:23:42+00:00",
+    "end": "2024-12-05T08:00:00+00:00",
+    "modified": "2024-12-05T18:31:20+00:00",
+    "external_desc": "November 2024 core update",
+    "updates": [
+      {
+        "created": "2024-12-05T18:31:17+00:00",
+        "modified": "2024-12-05T18:31:20+00:00",
+        "when": "2024-12-05T18:31:17+00:00",
+        "text": "The rollout was complete as of December 5, 2024.",
+        "status": "AVAILABLE"
+      },
+      {
+        "created": "2024-11-11T21:23:42+00:00",
+        "modified": "2024-12-05T18:31:17+00:00",
+        "when": "2024-11-11T21:23:42+00:00",
+        "text": "Released the November 2024 core update <https://developers.google.com/search/updates/core-updates>. The rollout may take up to 2 weeks to complete.",
+        "status": "SERVICE_INFORMATION"
+      }
+    ],
+    "most_recent_update": {
+      "created": "2024-12-05T18:31:17+00:00",
+      "modified": "2024-12-05T18:31:20+00:00",
+      "when": "2024-12-05T18:31:17+00:00",
+      "text": "The rollout was complete as of December 5, 2024.",
+      "status": "AVAILABLE"
+    },
+    "status_impact": "SERVICE_INFORMATION",
+    "severity": "low",
+    "service_key": "rGHU1u87FJnkP6W2GwMi",
+    "service_name": "Ranking",
+    "affected_products": [
+      {
+        "title": "Ranking",
+        "id": "rGHU1u87FJnkP6W2GwMi"
+      }
+    ],
+    "uri": "incidents/G7rp11wqTaTGn6JjiPF3"
+  }
+]


### PR DESCRIPTION
## Summary
- fetch Google Search status updates and cache them locally
- expose `get_recent_updates` to retrieve recent incidents
- add `--check-updates` flag to show new updates after scraping

## Testing
- `python -m py_compile google_updates.py scrape.py`
- `python scrape.py --check-updates`

------
https://chatgpt.com/codex/tasks/task_b_68ba6288c3308322b7a91c6e542028c2